### PR TITLE
Add login template to all API views

### DIFF
--- a/pollsapi/polls/urls.py
+++ b/pollsapi/polls/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from django.conf.urls import include
 from rest_framework.routers import DefaultRouter
 
 # from .views import polls_list, polls_detail
@@ -13,6 +14,7 @@ urlpatterns = [
     # path("polls/<int:pk>", polls_detail, name="polls_detail")
     # path("polls/", PollList.as_view(), name="polls_list"),
     # path("polls/<int:pk>/", PollDetail.as_view(), name="polls_detail"),
+    path('/', include('rest_framework.urls')),
     path("login/", LoginView.as_view(), name="login"),
     path("polls/<int:pk>/choices/", ChoiceList.as_view(), name="choice_list"),
     path("polls/<int:pk>/choices/<int:choice_pk>/vote/", CreateVote.as_view(), name="create_vote"),


### PR DESCRIPTION
Users who want to use API generics views need to login as a user
with a token in advance. This change adds login template to all
API views so that all users are available to use the given APIs.

Closes: #34