### PR TITLE
Set default configuration of polls application

### DIFF
--- a/pollsapi/polls/__init__.py
+++ b/pollsapi/polls/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'polls.apps.PollsConfig'


### PR DESCRIPTION
default_app_config allows you to make use of AppConfig features
without requiring users to update their INSTALLED_APPS setting.